### PR TITLE
small fix relating to searching memory-loaded modules for named resources

### DIFF
--- a/MemoryModule.c
+++ b/MemoryModule.c
@@ -633,7 +633,7 @@ static PIMAGE_RESOURCE_DIRECTORY_ENTRY _MemorySearchResourceEntry(
         int searchKeyLength = 0;
 #endif
         start = 0;
-        end = resources->NumberOfIdEntries;
+        end = resources->NumberOfNamedEntries;
         while (end > start) {
             // resource names are always stored using 16bit characters
             int cmp;


### PR DESCRIPTION
The change fixed the problem I was having trying to load a named resource. Thanks for writing this great library!