### PR TITLE
Pass alloc/free functions to MemoryLoadLibraryEx

### DIFF
--- a/MemoryModule.h
+++ b/MemoryModule.h
@@ -39,6 +39,8 @@ typedef void *HCUSTOMMODULE;
 extern "C" {
 #endif
 
+typedef LPVOID (*CustomAllocFunc)(LPVOID, SIZE_T, DWORD, DWORD, void*);
+typedef BOOL (*CustomFreeFunc)(LPVOID, SIZE_T, DWORD, void*);
 typedef HCUSTOMMODULE (*CustomLoadLibraryFunc)(LPCSTR, void *);
 typedef FARPROC (*CustomGetProcAddressFunc)(HCUSTOMMODULE, LPCSTR, void *);
 typedef void (*CustomFreeLibraryFunc)(HCUSTOMMODULE, void *);
@@ -58,6 +60,8 @@ HMEMORYMODULE MemoryLoadLibrary(const void *, size_t);
  * Dependencies will be resolved using passed callback methods.
  */
 HMEMORYMODULE MemoryLoadLibraryEx(const void *, size_t,
+    CustomAllocFunc,
+    CustomFreeFunc,
     CustomLoadLibraryFunc,
     CustomGetProcAddressFunc,
     CustomFreeLibraryFunc,
@@ -116,6 +120,22 @@ int MemoryLoadString(HMEMORYMODULE, UINT, LPTSTR, int);
  * Load a string resource with a given language.
  */
 int MemoryLoadStringEx(HMEMORYMODULE, UINT, LPTSTR, int, WORD);
+
+/**
+* Default implementation of CustomAllocFunc that calls VirtualAlloc
+* internally to allocate memory for a library
+*
+* This is the default as used by MemoryLoadLibrary.
+*/
+LPVOID MemoryDefaultAlloc(LPVOID, SIZE_T, DWORD, DWORD, void *);
+
+/**
+* Default implementation of CustomFreeFunc that calls VirtualFree
+* internally to free the memory used by a library
+*
+* This is the default as used by MemoryLoadLibrary.
+*/
+BOOL MemoryDefaultFree(LPVOID, SIZE_T, DWORD, void *);
 
 /**
  * Default implementation of CustomLoadLibraryFunc that calls LoadLibraryA

--- a/example/DllLoader/DllLoader.cpp
+++ b/example/DllLoader/DllLoader.cpp
@@ -130,11 +130,161 @@ exit:
     free(data);
 }
 
+#define MAX_CALLS 20
+
+struct CallList {
+    int current_alloc_call, current_free_call;
+    CustomAllocFunc alloc_calls[MAX_CALLS];
+    CustomFreeFunc free_calls[MAX_CALLS];
+};
+
+LPVOID MemoryFailingAlloc(LPVOID address, SIZE_T size, DWORD allocationType, DWORD protect, void* userdata)
+{
+    UNREFERENCED_PARAMETER(address);
+    UNREFERENCED_PARAMETER(size);
+    UNREFERENCED_PARAMETER(allocationType);
+    UNREFERENCED_PARAMETER(protect);
+    UNREFERENCED_PARAMETER(userdata);
+    return NULL;
+}
+
+LPVOID MemoryMockAlloc(LPVOID address, SIZE_T size, DWORD allocationType, DWORD protect, void* userdata)
+{
+    CallList* calls = (CallList*)userdata;
+    CustomAllocFunc current_func = calls->alloc_calls[calls->current_alloc_call++];
+    assert(current_func != NULL);
+    return current_func(address, size, allocationType, protect, NULL);
+}
+
+BOOL MemoryMockFree(LPVOID lpAddress, SIZE_T dwSize, DWORD dwFreeType, void* userdata)
+{
+    CallList* calls = (CallList*)userdata;
+    CustomFreeFunc current_func = calls->free_calls[calls->current_free_call++];
+    assert(current_func != NULL);
+    return current_func(lpAddress, dwSize, dwFreeType, NULL);
+}
+
+void InitFuncs(void** funcs, va_list args) {
+    for (int i = 0; ; i++) {
+        assert(i < MAX_CALLS);
+        funcs[i] = va_arg(args, void*);
+        if (funcs[i] == NULL) break;
+    }
+}
+
+void InitAllocFuncs(CallList* calls, ...) {
+    va_list args;
+    va_start(args, calls);
+    InitFuncs((void**)calls->alloc_calls, args);
+    va_end(args);
+    calls->current_alloc_call = 0;
+}
+
+void InitFreeFuncs(CallList* calls, ...) {
+    va_list args;
+    va_start(args, calls);
+    InitFuncs((void**)calls->free_calls, args);
+    va_end(args);
+    calls->current_free_call = 0;
+}
+
+void InitFreeFunc(CallList* calls, CustomFreeFunc freeFunc) {
+	for (int i = 0; i < MAX_CALLS; i++) {
+		calls->free_calls[i] = freeFunc;
+	}
+	calls->current_free_call = 0;
+}
+
+void TestFailingAllocation(void *data, long size) {
+    CallList expected_calls;
+    HMEMORYMODULE handle;
+
+    InitAllocFuncs(&expected_calls, MemoryFailingAlloc, MemoryFailingAlloc, NULL);
+    InitFreeFuncs(&expected_calls, NULL);
+
+    handle = MemoryLoadLibraryEx(
+        data, size, MemoryMockAlloc, MemoryMockFree, MemoryDefaultLoadLibrary,
+        MemoryDefaultGetProcAddress, MemoryDefaultFreeLibrary, &expected_calls);
+
+    assert(handle == NULL);
+    assert(GetLastError() == ERROR_OUTOFMEMORY);
+    assert(expected_calls.current_free_call == 0);
+
+    MemoryFreeLibrary(handle);
+    assert(expected_calls.current_free_call == 0);
+}
+
+void TestCleanupAfterFailingAllocation(void *data, long size) {
+    CallList expected_calls;
+    HMEMORYMODULE handle;
+    int free_calls_after_loading;
+
+    InitAllocFuncs(&expected_calls,
+        MemoryDefaultAlloc,
+        MemoryDefaultAlloc,
+        MemoryDefaultAlloc,
+        MemoryDefaultAlloc,
+        MemoryFailingAlloc,
+        NULL);
+    InitFreeFuncs(&expected_calls, MemoryDefaultFree, NULL);
+
+    handle = MemoryLoadLibraryEx(
+        data, size, MemoryMockAlloc, MemoryMockFree, MemoryDefaultLoadLibrary,
+        MemoryDefaultGetProcAddress, MemoryDefaultFreeLibrary, &expected_calls);
+
+    free_calls_after_loading = expected_calls.current_free_call;
+
+    MemoryFreeLibrary(handle);
+    assert(expected_calls.current_free_call == free_calls_after_loading);
+}
+
+void TestFreeAfterDefaultAlloc(void *data, long size) {
+    CallList expected_calls;
+    HMEMORYMODULE handle;
+    int free_calls_after_loading;
+
+	// Note: free might get called internally multiple times
+    InitFreeFunc(&expected_calls, MemoryDefaultFree);
+
+    handle = MemoryLoadLibraryEx(
+        data, size, MemoryDefaultAlloc, MemoryMockFree, MemoryDefaultLoadLibrary,
+        MemoryDefaultGetProcAddress, MemoryDefaultFreeLibrary, &expected_calls);
+
+    assert(handle != NULL);
+    free_calls_after_loading = expected_calls.current_free_call;
+
+    MemoryFreeLibrary(handle);
+    assert(expected_calls.current_free_call == free_calls_after_loading + 1);
+}
+
+void TestCustomAllocAndFree(void)
+{
+    void *data;
+    long size;
+
+    data = ReadLibrary(&size);
+    if (data == NULL)
+    {
+        return;
+    }
+
+    _tprintf(_T("Test MemoryLoadLibraryEx after initially failing allocation function\n"));
+    TestFailingAllocation(data, size);
+    _tprintf(_T("Test cleanup after MemoryLoadLibraryEx with failing allocation function\n"));
+    TestCleanupAfterFailingAllocation(data, size);
+    _tprintf(_T("Test custom free function after MemoryLoadLibraryEx\n"));
+    TestFreeAfterDefaultAlloc(data, size);
+
+    free(data);
+}
+
 int main()
 {
     LoadFromFile();
     printf("\n\n");
     LoadFromMemory();
+    printf("\n\n");
+    TestCustomAllocAndFree();
     return 0;
 }
 


### PR DESCRIPTION
This is driven by a problem I solved recently. And MemoryModule helped me a lot. It works great, it's simple, it's well written and does what it should. So thanks for the great library!

The problem I was solving - I have some legacy x86 code that I want to call from an executable that I'm writing. When I say "legacy" - I mean I only have binaries. The challenge is that the code is not relocatable. That's a bit of a problem on a modern Windows. I came to the conclusion that it's virtually impossible to consistently get the base address that I want at runtime.

With some compiler/linker magic I was able to reserve a section in the image at the offset I want. However, this does not play well with the current interface of MemoryModule. The `MemoryLoadLibrary` function wants to allocate the memory itself and would not work with my memory chunk.

What I did was pass `alloc` and `free` functions to `MemoryLoadLibraryEx` and use those instead. The default implementations just call `VirtualAlloc`/`VirtualFree`. My implementation sets memory permissions on the pre-allocated memory. Here is a rough example of what I'm doing:
```C
static LPVOID _MyAlloc(LPVOID address, SIZE_T size, DWORD allocationType, DWORD protect, void* userdata) {
	if (address < LEGACY_IMAGE_BASE || address >= LEGACY_IMAGE_BASE) {
		return VirtualAlloc(address, size, allocationType, protect);
	}
	DWORD old_protect;
	BOOL success = VirtualProtect(address, size, protect, &old_protect);
	if (success) {
		return address;
	}
	else {
		return nullptr;
	}
}

/* some more code.... and then: */
MemoryLoadLibraryEx(address, size, _MyAlloc, _MyFree, _LoadLibrary, _GetProcAddress, _FreeLibrary, NULL);
```

I hope it's not an issue that this changes the interface of `MemoryLoadLibraryEx`. My rationale behind it is that this is not a public API. At least I didn't find any references to it in the documentation at http://www.joachim-bauch.de/tutorials/loading-a-dll-from-memory/

TL;DR
This pull request allows for `MemoryLoadLibraryEx` to work with memory allocations different from calls to `VirtualAlloc`.