### PR TITLE
flush instruction cache after performing relocations

### DIFF
--- a/MemoryModule.c
+++ b/MemoryModule.c
@@ -645,6 +645,9 @@ HMEMORYMODULE MemoryLoadLibraryEx(const void *data, size_t size,
     } else {
         result->isRelocated = TRUE;
     }
+	
+    // flush instruction cache to avoid executing stale code after performing relocations
+    FlushInstructionCache((HANDLE)-1, NULL, 0);
 
     // load required dlls and adjust function table of imports
     if (!BuildImportTable(result)) {


### PR DESCRIPTION
Flush instruction cache to avoid executing stale code after performing relocations.
According to MSDN: "Applications should call FlushInstructionCache if they generate or modify code in memory. The CPU cannot detect the change, and may execute the old code it cached.".
After performing relocation we have modified executable code, so if we don't flush the cache maybe the old code without relocation is executed instead. So far the code has woked without flushing instruction cache but it's better to be safe.

https://msdn.microsoft.com/en-us/library/windows/desktop/ms679350(v=vs.85).aspx