### PR TITLE
Make .h file accessible to superprojects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ else ()
 endif ()
 
 add_library (MemoryModule STATIC MemoryModule.c MemoryModule.h)
+target_include_directories(MemoryModule PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 if (NOT MSVC)
     set_target_properties ("MemoryModule" PROPERTIES PREFIX "")
 endif ()


### PR DESCRIPTION
As is, you need to add_subdirectory and also add the include, this kills two birds with one stone