### PR TITLE
Fix SectionAlignment

### DIFF
--- a/MemoryModule.c
+++ b/MemoryModule.c
@@ -609,9 +609,8 @@ HMEMORYMODULE MemoryLoadLibraryEx(const void *data, size_t size,
         }
     }
 
-    GetNativeSystemInfo(&sysInfo);
-    alignedImageSize = AlignValueUp(old_header->OptionalHeader.SizeOfImage, sysInfo.dwPageSize);
-    if (alignedImageSize != AlignValueUp(lastSectionEnd, sysInfo.dwPageSize)) {
+    alignedImageSize = AlignValueUp(old_header->OptionalHeader.SizeOfImage, old_header->OptionalHeader.SectionAlignment);
+    if (alignedImageSize != AlignValueUp(lastSectionEnd, old_header->OptionalHeader.SectionAlignment)) {
         SetLastError(ERROR_BAD_EXE_FORMAT);
         return NULL;
     }


### PR DESCRIPTION
Some dlls do not use Native SectionAlignment, instead use SectionAlignment from PE.
Issue 54 should be solved then: https://github.com/fancycode/MemoryModule/issues/54