### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/doc/readme.rst
+++ b/doc/readme.rst
@@ -523,6 +523,17 @@ The latest development release can always be grabbed from Github at
 http://github.com/fancycode/MemoryModule/
 
 
+Building MemoryModule with vcpkg
+---------------------------------
+The MemoryModule port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please create an issue or pull request on the vcpkg repository. The url of vcpkg is: https://github.com/Microsoft/vcpkg . You can download and install MemoryModule using the vcpkg dependency manager:
+
+1. git clone https://github.com/Microsoft/vcpkg.git
+2. cd vcpkg
+3. ./bootstrap-vcpkg.sh
+4. ./vcpkg integrate install
+5. ./vcpkg install memorymodule
+
+
 Known issues
 -------------
 

--- a/doc/readme.rst
+++ b/doc/readme.rst
@@ -529,7 +529,7 @@ The MemoryModule port in vcpkg is kept up to date by Microsoft team members and 
 
 1. git clone https://github.com/Microsoft/vcpkg.git
 2. cd vcpkg
-3. ./bootstrap-vcpkg.sh
+3. ./bootstrap-vcpkg.bat
 4. ./vcpkg integrate install
 5. ./vcpkg install memorymodule
 


### PR DESCRIPTION
MemoryModule is available as a port in vcpkg, a C++ library manager that simplifies installation for MemoryModule and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build MemoryModule, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here](https://github.com/microsoft/vcpkg/blob/master/ports/memorymodule/portfile.cmake) is what the port script looks like. We try to keep the library maintained as close as possible to the original library.