### PR TITLE
fix a bug in PerformBaseRelocation

### DIFF
--- a/MemoryModule.c
+++ b/MemoryModule.c
@@ -382,6 +382,7 @@ static BOOL
 PerformBaseRelocation(PMEMORYMODULE module, ptrdiff_t delta)
 {
     unsigned char *codeBase = module->codeBase;
+    DWORD          relocation_size;
     PIMAGE_BASE_RELOCATION relocation;
 
     PIMAGE_DATA_DIRECTORY directory = GET_HEADER_DICTIONARY(module, IMAGE_DIRECTORY_ENTRY_BASERELOC);
@@ -389,11 +390,16 @@ PerformBaseRelocation(PMEMORYMODULE module, ptrdiff_t delta)
         return (delta == 0);
     }
 
+    relocation_size = directory->Size;
     relocation = (PIMAGE_BASE_RELOCATION) (codeBase + directory->VirtualAddress);
-    for (; relocation->VirtualAddress > 0; ) {
+    
+    for (;relocation_size; ) {
         DWORD i;
         unsigned char *dest = codeBase + relocation->VirtualAddress;
         unsigned short *relInfo = (unsigned short*) OffsetPointer(relocation, IMAGE_SIZEOF_BASE_RELOCATION);
+
+        relocation_size -= relocation->SizeOfBlock;
+
         for (i=0; i<((relocation->SizeOfBlock-IMAGE_SIZEOF_BASE_RELOCATION) / 2); i++, relInfo++) {
             // the upper 4 bits define the type of relocation
             int type = *relInfo >> 12;


### PR DESCRIPTION
## Bug
The end cannot be determined based on whether the Virtual Address of the next IMAGE_BASE_RELOCATION is 0 or not. In fact, it is possible that the next IMAGE_BASE_RELOCATION exceeds the size of the entire directory. 
The data it contains is completely uncertain.

Instead, use directory size to determine if you've reached the end.


## Sample: 
![image](https://github.com/fancycode/MemoryModule/assets/83495929/bf03c71b-74ad-4992-8e1b-f084757a0660)


By the time you get to the end, you have exceeded the size of the entire relocation table, and the memory after that is invalid, which will cause an exception if you use the Virtual Address

![image](https://github.com/fancycode/MemoryModule/assets/83495929/95835fa1-55a1-47e0-b429-21eea04b771e)

![image](https://github.com/fancycode/MemoryModule/assets/83495929/44701b96-84eb-4f6c-8c00-4aa6bc10b7d0)


## Why does this approach work most of the time?

The secetion in which the relocation table is located is page aligned, and in most cases there is memory for alignment behind the relocation table, which is filled with 0x00.

![image](https://github.com/fancycode/MemoryModule/assets/83495929/dfd86b0e-a7ee-44ac-a1fc-4ed7ba42c5f3)
